### PR TITLE
Fix missing port number in m= SDP fragments

### DIFF
--- a/whep.js
+++ b/whep.js
@@ -240,7 +240,7 @@ export class WHEPClient {
 		for (const media of Object.values(medias)) {
 			//Add media to fragment
 			fragment +=
-				"m=" + media.kind + " RTP/AVP 0\r\n" +
+				"m=" + media.kind + " 9 RTP/AVP 0\r\n" +
 				"a=mid:" + media.mid + "\r\n";
 			//Add candidate
 			for (const candidate of media.candidates)

--- a/whip.js
+++ b/whip.js
@@ -252,7 +252,7 @@ export class WHIPClient
 		{
 			//Add media to fragment
 			fragment += 
-				"m="+ media.kind + " RTP/AVP 0\r\n" +
+				"m="+ media.kind + " 9 RTP/AVP 0\r\n" +
 				"a=mid:"+ media.mid + "\r\n";
 			//Add candidate
 			for (const candidate of media.candidates)


### PR DESCRIPTION
I think (sorry if I am wrong) the code to generate SDP fragments needs to also output port numbers
for the m=audio/m=video lines.

The SDP RFC ABNF seems to require it, and as far as I can tell this is just a small bug in the code and WHIP draft.
