### PR TITLE
Fix splitting of link header subitems

### DIFF
--- a/whep.js
+++ b/whep.js
@@ -113,7 +113,7 @@ export class WHEPClient extends EventTarget
 					for (let i = 1; i < items.length; ++i)
 					{
 						//Split into key/val
-						const subitems = items[i].split("=");
+						const subitems = items[i].split(/=(.*)/);
 						//Get key
 						const key = subitems[0].trim();
 						//Unquote value


### PR DESCRIPTION
This PR fixes the parsing of link header values that contain equals signs:

Before this change:
* Input: `"credential=\"foo=\""`
* Expected: `["credential", "\"foo=\""]`
* Actual: `["credential", "\"foo", "\""]`

After this change:
* Input: `"credential=\"foo=\""`
* Expected: `["credential", "\"foo=\""]`
* Actual: `["credential", "\"foo=\""]`