### PR TITLE
Fix peer connection reference in restart method

### DIFF
--- a/whep.js
+++ b/whep.js
@@ -287,7 +287,7 @@ export class WHEPClient extends EventTarget
 		if (restartIce)
 		{
 			//Restart ice
-			pc.restartIce();
+			this.pc.restartIce();
 			//Create a new offer
 			const offer = await this.pc.createOffer({ iceRestart: true });
 			//Update ice


### PR DESCRIPTION
Minor fix to `restart()` method: `pc` is a property of the context object, not a standalone variable.