### PR TITLE
Don't throw Error on fetch PATCH 501, 405 status

### DIFF
--- a/whep.js
+++ b/whep.js
@@ -370,7 +370,7 @@ export class WHEPClient extends EventTarget
 			body: fragment,
 			headers
 		});
-		if (!fetched.ok)
+		if (!fetched.ok && fetched.status != 501 && fetched.status != 405)
 			throw new Error("Request rejected with status " + fetched.status)
 
 		//If we have got an answer


### PR DESCRIPTION
Resubmitting this to be cleaner. Last PR had 47 line changes due to CRLF issues.

From my reading of the whep draft, the client can and should continue in spite of a 501 or 405 status from the whep resource/server.

Resubmission of #10 

