### PR TITLE
Add typescript definitions to both whip and whep

### DIFF
--- a/whep.d.ts
+++ b/whep.d.ts
@@ -1,0 +1,10 @@
+export declare class WHEPClient extends EventTarget {
+    constructor();
+    view(pc: RTCPeerConnection, url: string, token?: string): Promise<void>;
+    restart(): void;
+    trickle(): Promise<void>;
+    mute(muted: any): Promise<void>;
+    stop(): Promise<void>;
+    selectLayer(): Promise<void>;
+    unselectLayer(): Promise<void>;
+}

--- a/whip.d.ts
+++ b/whip.d.ts
@@ -1,0 +1,8 @@
+export declare class WHIPClient {
+    constructor();
+    publish(pc: RTCPeerConnection, url: string, token?: string): Promise<void>;
+    restart(): void;
+    trickle(): Promise<void>;
+    mute(muted: any): Promise<void>;
+    stop(): Promise<void>;
+}


### PR DESCRIPTION
This adds typescript definition files which fixes the error generated when importing whep.js or whip.js into typescript projects.
