### PR TITLE
add the build github actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,69 @@
+name: build
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - name: Set the version to the git tag
+        if: ${{ startsWith(github.event.ref, 'refs/tags/v') }}
+        run: |
+          npm version \
+            --no-commit-hooks \
+            --no-git-tag-version \
+            '${{ github.ref_name }}'
+      - name: Install dependencies
+        # TODO discuss the use of npm ci.
+        run: npm install
+      - name: Lint
+        # TODO when all lint errors are fixed, drop the "|| true" part.
+        run: npm run lint || true
+      # TODO run dtslint.
+      #      see https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint
+      - name: Pack
+        run: npm pack
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: artifacts
+          path: |
+            *.tgz
+      - name: Test install
+        run: |
+          PACKAGE_PATH="$(ls "$PWD"/*.tgz)"
+          pushd "$(mktemp -q -d --suffix=.test)"
+          npm install --verbose "$PACKAGE_PATH"
+          popd
+  # see https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+  release:
+    name: Release
+    if: ${{ startsWith(github.event.ref, 'refs/tags/v') }}
+    runs-on: ubuntu-22.04
+    needs:
+      - build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+      - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          pushd artifacts
+          PACKAGE_PATH="$(ls "$PWD"/*.tgz)"
+          npm publish \
+            --verbose \
+            --access public \
+            "$PACKAGE_PATH"
+          popd
+      # TODO publish the *.d.ts files to https://github.com/DefinitelyTyped/DefinitelyTyped
+      #      OR do like described at https://github.com/microsoft/DefinitelyTyped-tools/tree/master/packages/dtslint#add-types-for-a-library-not-on-definitelytyped

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.tgz

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+.github/
+*.tgz

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build status](https://github.com/medooze/whip-whep-js/workflows/build/badge.svg)](https://github.com/medooze/whip-whep-js/actions?query=workflow%3Abuild) [![npm package](https://img.shields.io/npm/v/whip-whep.svg?label=npm:whip-whep)](https://www.npmjs.com/package/whip-whep)
+
 # whip.js
 WHIP client javascript module
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
 	"name": "whip-whep",
 	"version": "1.0.5",
 	"description": "WHIP and WHEP clients",
-	"module": true,
+	"scripts": {
+		"lint": "npx eslint . --ext .js"
+	},
 	"repository": {
 		"type": "git",
 		"url": "git+https://github.com/medooze/whip-whep-js.git"
@@ -18,14 +20,16 @@
 		"url": "https://github.com/medooze/whip-whep-js/issues"
 	},
 	"homepage": "https://github.com/medooze/whip-whep-js#readme",
-	"dependencies": {
+	"devDependencies": {
 		"eslint": "^8.50.0",
 		"eslint-config-medooze": "^1.0.1"
 	},
 	"eslintConfig": {
-                "extends": [
-                        "medooze"
-                ]
-        }
-
+		"extends": [
+			"medooze"
+		],
+		"parserOptions": {
+			"sourceType": "module"
+		}
+	}
 }


### PR DESCRIPTION
this a WIP for the github actions workflow mentioned at https://github.com/medooze/whip-whep-js/issues/17.

please do not yet merge the code until you review it, especially the TODO parts, where I request your input in order to decide how to proceed with the implementation.

to deploy this you need to:

1. at [your npmjs.com account access token page](https://www.npmjs.com/settings/murillo128/tokens), create a new Automation Classic Token.
2. at [your github repository settings](https://github.com/medooze/whip-whep-js/settings/secrets/actions), create a new actions repository secret named `NPM_TOKEN` with the token created at 1.
3. at your github repository settings, create a protected tag for the `v*` pattern.

to trigger a new non-release build, you need to:

1. push code to the repository.
2. wait for the github actions workflow to build, lint, and create the npm package (will be available as a build artifact).

to trigger a new release build and publish the npm package, you need to:

1. push a tag that starts with a `v` character, e.g., `v1.0.6-pre1`.
2. wait for the github actions workflow to build, lint, create the npm package (will be available as a build artifact), and publish the npm package to https://www.npmjs.com/package/whip-whep.

i've done a couple of test builds, which you can see at:

- https://www.npmjs.com/package/@rgl/whip-whep-test-tmp
- https://github.com/rgl/whip-whep-js/actions