### PR TITLE
A patch response with multiple candidates lead to bad SDP answer

### DIFF
--- a/whip.js
+++ b/whip.js
@@ -365,8 +365,7 @@ export class WHIPClient
 			remoteDescription.sdp = remoteDescription.sdp.replaceAll(/(a=candidate:.*\r\n)/gm, "");
 
 			//Add candidates
-			remoteDescription.sdp = remoteDescription.sdp.replaceAll(/(m=.*\r\n)/gm, "$1" + candidates.join());
-
+			remoteDescription.sdp = remoteDescription.sdp.replaceAll(/(m=.*\r\n)/gm, "$1" + candidates.join(''));
 			//Set it
 			await this.pc.setRemoteDescription(remoteDescription);
 


### PR DESCRIPTION
The candidates of the patch response are concatenated with `join()` before being injected in the SDP.
But `join()` is equivalent to `join(,)`, which can lead to bad SDP in case of multiple candidates.
We can use `join('')` instead.